### PR TITLE
Update devices regexp

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ansible-role-disk-scheduler
 #
  - name: get list of block devices to test
-   shell: ls /sys/block/ | egrep '^([shv]|xv])d[a-z]$'
+   shell: ls /sys/block/ | egrep '^([shv]|xv)d[a-z]$'
    register: block_devs
    changed_when: no
 


### PR DESCRIPTION
It seems that regexp currently is a bit wrong and doesn't catch devices that starts with `xv`. 